### PR TITLE
chore: V0 Schema expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expand `#/components/schemas/VatCodeUpsert` to use less inheritance.
 - Expand `#/components/schemas/Vendor` definition to use less inheritance.
 - Expand `#/components/schemas/VendorUpsert` definition to use less inheritance.
+- Expand `#/components/schemas/VendorConfirm` definition to use less inheritance.
 
 
 ## v0.3.10

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2784,10 +2784,18 @@ components:
             internalId:
               $ref: '#/components/schemas/InternalId'
     VendorConfirm:
-      allOf:
-        - required:
-            - externalId
-        - $ref: '#/components/schemas/UpsertCommon'
+      type: object
+      required:
+      - externalId
+      - externalUpdatedAt
+      properties:
+        externalId:
+          $ref: '#/components/schemas/ExternalId'
+        externalUpdatedAt:
+          type: string
+          format: date-time
+          description: note that externalUpdatedAt does NOT have UTC normalization
+          example: '2021-06-29T17:20:53.154'
     SubscriptionUpsert:
       type: object
       properties:


### PR DESCRIPTION
We need to expand all of the places where we are using inheritance. It is causing issues with `openapi_spec_validator` and makes comprehending what the shape of the object to pass is supposed to be.

Yes it is a little more verbose but overall, I believe it is an improvement.