### PR TITLE
chore: Update Vendor documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.3.15
 ### V0
 - Added `description` to `#/components/schemas/Vendor`.
+- Added `VendorTaxInfo` to `#/components/schemas/VendorTaxInfo`.
+- Removed `#/components/schemas/TaxInfoUS`. Has been combined to `#/components/schemas/VendorTaxInfo`.
+- Removed `#/components/schemas/TaxInfoSE`. Has been combined to `#/components/schemas/VendorTaxInfo`.
+- Removed `#/components/schemas/TaxInfoNO`. Has been combined to `#/components/schemas/VendorTaxInfo`.
 
 
 ## v0.3.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 
+## v0.3.15
+### V0
+- Added `description` to `#/components/schemas/Vendor`.
+
+
 ## v0.3.14
 ### Added in V1
 - Added `POST /v1/purchase_orders` to create a purchase order.

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.3.13
+  version: 0.3.15
   contact: {}
   title: Vic.Api
   description: |

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2704,6 +2704,9 @@ components:
           format: email
           maxLength: 255
           nullable: true
+        description:
+          type: string
+          nullable: true
         phone:
           type: string
           nullable: true

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2736,10 +2736,7 @@ components:
         state:
           $ref: "#/components/schemas/VendorState"
         taxInfo:
-          anyOf:
-          - $ref: '#/components/schemas/TaxInfoUS'
-          - $ref: '#/components/schemas/TaxInfoSE'
-          - $ref: '#/components/schemas/TaxInfoNO'
+          $ref: '#/components/schemas/VendorTaxInfo'
         defaultPaymentInfo:
           anyOf:
           - $ref: '#/components/schemas/PaymentInfoUS'
@@ -2806,10 +2803,7 @@ components:
         state:
           $ref: "#/components/schemas/VendorState"
         taxInfo:
-          anyOf:
-          - $ref: '#/components/schemas/TaxInfoUS'
-          - $ref: '#/components/schemas/TaxInfoSE'
-          - $ref: '#/components/schemas/TaxInfoNO'
+          $ref: '#/components/schemas/VendorTaxInfo'
         defaultPaymentInfo:
           anyOf:
           - $ref: '#/components/schemas/PaymentInfoUS'
@@ -2875,10 +2869,7 @@ components:
         state:
           $ref: "#/components/schemas/VendorState"
         taxInfo:
-          anyOf:
-            - $ref: '#/components/schemas/TaxInfoUS'
-            - $ref: '#/components/schemas/TaxInfoSE'
-            - $ref: '#/components/schemas/TaxInfoNO'
+          $ref: '#/components/schemas/VendorTaxInfo'
         defaultPaymentInfo:
           anyOf:
             - $ref: '#/components/schemas/PaymentInfoUS'
@@ -3047,29 +3038,17 @@ components:
         - INVOICE
         - CREDITNOTE
       default: INVOICE
-    TaxInfoUS:
+    VendorTaxInfo:
       type: object
-      required:
-        - taxId
       properties:
         taxId:
           type: string
+          nullable: true
         is1099vendor:
           type: boolean
-    TaxInfoSE:
-      type: object
-      required:
-        - orgNumber
-      properties:
         orgNumber:
           type: string
-    TaxInfoNO:
-      type: object
-      required:
-        - orgNumber
-      properties:
-        orgNumber:
-          type: string
+          nullable: true
     PaymentInfoUS:
       type: object
       required:

--- a/vic.api.v1.yaml
+++ b/vic.api.v1.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.3.13
+  version: 0.3.15
   contact: {}
   title: Vic.Api
   description: |


### PR DESCRIPTION
* Adds `description` to the `V0` `Vendor` object.
* Replaces `TaxInfoUs`, `TaxInfoSe`, and `TaxInfoNo` with a simplified `VendorTaxInfo` model.
* Bumps schema version to `v0.3.15`