### PR TITLE
fix: Set cost account number field to follow a numeric pattern.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.3.19
+### V0
+- Changed `Account` `number` to only permit the pattern `^\d+$`.
+
 
 ## v0.3.18
 ### V0

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.3.18
+  version: 0.3.19
   contact: {}
   title: Vic.Api
   description: |
@@ -1870,6 +1870,7 @@ components:
         number:
           type: string
           format: number
+          pattern: '^\d+$'
         name:
           type: string
           maxLength: 255
@@ -1906,6 +1907,7 @@ components:
         number:
           type: string
           format: number
+          pattern: '^\d+$'
         name:
           type: string
           maxLength: 255
@@ -2057,6 +2059,7 @@ components:
           description: The cost account's number.
           type: string
           maxLength: 255
+          pattern: '^\d+$'
           nullable: true
     PaymentKind:
       description: The payment kind.


### PR DESCRIPTION
This was requested to set a formal pattern on the cost account's number field to only support digits.

We are planning to support alphanumeric in the future, but we have no ETA on that.