### PR TITLE
docs: Fix ExternalId schema description

### DIFF
--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1776,7 +1776,7 @@ components:
     ExternalId:
       description: |
         The external id set by the ERP system. It does not have to be a UUID and
-        can be any string desired.
+        can be any non empty string desired.
       type: string
       example: 21b31bc7-1267-4335-893c-d7fe4706a238
       maxLength: 255

--- a/vic.api.v1.yaml
+++ b/vic.api.v1.yaml
@@ -285,7 +285,7 @@ components:
     ExternalId:
       description: |
         The external id set by the ERP system. It does not have to be a UUID and
-        can be any string desired.
+        can be any non empty string desired.
       type: string
       example: 21b31bc7-1267-4335-893c-d7fe4706a238
       maxLength: 255


### PR DESCRIPTION
Clarification that `ExternalId` can be any non empty string.