### PR TITLE
fix: Remove unsupported fields from V0 Dimension and Account schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.4.0
+### V0
+- Removed `requiredDimensionsExternal` from `#/components/schemas/Account`. This field was never supported.
+- Removed `parentAccountExternalId` from `#/components/schemas/Account`. This field was never supported.
+- Removed `requiredDimensionsInternal` from `#/components/schemas/Account`. This field was never supported.
+- Removed `parentAccountInternalId` from `#/components/schemas/Account`. This field was never supported.
+- Removed `requiredDimensionsExternal` from `#/components/schemas/AccountUpsert`. This field was never supported.
+- Removed `parentAccountExternalId` from `#/components/schemas/AccountUpsert`. This field was never supported.
+- Removed `parentDimensionExternalId` from `#/components/schemas/Dimension`. This field was never supported.
+- Removed `parentDimensionInternalId` from `#/components/schemas/Dimension`. This field was never supported.
+- Removed `parentDimensionExternalId` from `#/components/schemas/DimensionUpsert`. This field was never supported.
+
+
 ## v0.3.19
 ### V0
 - Changed `Account` `number` to only permit the pattern `^\d+$`.

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.3.19
+  version: 0.4.0
   contact: {}
   title: Vic.Api
   description: |
@@ -1878,18 +1878,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/ExternalData'
           nullable: true
-        requiredDimensionsExternal:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExternalId'
-        parentAccountExternalId:
-          $ref: '#/components/schemas/ExternalId'
-        requiredDimensionsInternal:
-          type: array
-          items:
-            $ref: '#/components/schemas/InternalId'
-        parentAccountInternalId:
-          $ref: '#/components/schemas/InternalId'
     AccountUpsert:
       type: object
       required:
@@ -1915,12 +1903,6 @@ components:
           allOf:
           - $ref: '#/components/schemas/ExternalData'
           nullable: true
-        requiredDimensionsExternal:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExternalId'
-        parentAccountExternalId:
-          $ref: '#/components/schemas/ExternalId'
     Accounts:
       type: array
       items:
@@ -1944,12 +1926,8 @@ components:
           allOf:
           - $ref: '#/components/schemas/ExternalData'
           nullable: true
-        parentDimensionExternalId:
-          $ref: '#/components/schemas/ExternalId'
         displayName:
           type: string
-        parentDimensionInternalId:
-          $ref: '#/components/schemas/InternalId'
         internalId:
           $ref: '#/components/schemas/InternalId'
         internalUpdatedAt:
@@ -1987,8 +1965,6 @@ components:
           allOf:
           - $ref: '#/components/schemas/ExternalData'
           nullable: true
-        parentDimensionExternalId:
-          $ref: '#/components/schemas/ExternalId'
     Dimensions:
       type: array
       items:

--- a/vic.api.v1.yaml
+++ b/vic.api.v1.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.3.16
+  version: 0.4.0
   contact: {}
   title: Vic.Api
   description: |


### PR DESCRIPTION
These fields were specified but never mapped into anything. We do not currently support dimensions with parents and cost accounts with required dimensions being specified.