### PR TITLE
refactor: Make responses re-usable for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.6.0
+### V0
+- Lift all error responses to the `#/components/responses` section.
+- Replace `obtainToken` response with `#/components/responses/TokenCreatedResponse`
+- Replace `healthCheck` response with `#/components/responses/HealthyResponse`
+- Replace `listAccounts` response with `#/components/responses/AccountsResponse`
+- Replace `getAccount` response with `#/components/responses/AccountResponse`
+- Replace `upsertAccount` response with `#/components/responses/AccountUpsertedResponse`
+- Replace `deleteAccount` response with `#/components/responses/AccountDeletedResponse`
+- Replace `listDimensions` response with `#/components/responses/DimensionsResponse`
+- Replace `getDimension` response with `#/components/responses/DimensionResponse`
+- Replace `upsertDimension` response with `#/components/responses/DimensionCreatedResponse` and `#/components/responses/DimensionUpdatedResponse`
+- Replace `deleteDimension` response with `#/components/responses/DimensionDeletedResponse`
+- Replace `listVendors` response with `#/components/responses/VendorsResponse`
+- Replace `getVendor` response with `#/components/responses/VendorResponse`
+- Replace `upsertVendor` response with `#/components/responses/VendorCreatedResponse` and `#/components/responses/VendorUpdatedResponse`
+- Replace `deleteVendor` response with `#/components/responses/VendorDeletedResponse`
+- Replace `setVendorRemoteErrors` response with `#/components/responses/VendorRemoteErrorsUpdatedResponse`
+- Replace `clearVendorRemoteErrors` response with `#/components/responses/VendorRemoteErrorsClearedResponse`
+- Replace `listInvoices` response with `#/components/responses/InvoicesResponse`
+- Replace `createInvoice` response with `#/components/responses/InvoiceCreatedResponse`
+- Replace `getInvoice` response with `#/components/responses/InvoiceResponse`
+- Replace `ackInvoice` response with `#/components/responses/InvoiceResponse`
+- Replace `deleteInvoice` response with `#/components/responses/InvoiceDeletedResponse`
+- Replace `startProcessingInvoice` response with `#/components/responses/InvoiceResponse`
+- Replace `getInvoiceDocument` response with `#/components/responses/InvoiceDocumentResponse`
+- Replace `confirmInvoice` response with `#/components/responses/InvoiceConfirmedResponse`
+- Replace `rejectInvoice` response with `#/components/responses/InvoiceRejectedResponse`
+- Replace `getInvoicelineItems` response with `#/components/responses/InvoiceLineItemsResponse`
+- Replace `listTrainingInvoices` response with `#/components/responses/TrainingInvoicesResponse`
+- Replace `upsertTrainingInvoice` response with `#/components/responses/TrainingInvoiceUpsertedResponse`
+- Replace `deleteTrainingInvoice` response with `#/components/responses/TrainingInvoiceDeletedResponse`
+- Replace `getTrainingInvoiceDocument` response with `#/components/responses/TrainingInvoiceDocumentResponse`
+- Replace `listVatCodes` response with `#/components/responses/VatCodesResponse`
+- Replace `getVatCode` response with `#/components/responses/VatCodeResponse`
+- Replace `upsertVatCode` response with `#/components/responses/VatCodeUpsertedResponse`
+- Replace `deleteVatCode` response with `#/components/responses/VatCodeDeletedResponse`
+- Replace `getSubscription` response with `#/components/responses/SubscriptionResponse`
+- Replace `subscribe` response with `#/components/responses/SubscriptionUpsertedResponse`
+- Replace `unsubscribe` response with `#/components/responses/SubscriptionDeletedResponse`
+- Replace `getCostAccounts` response with `#/components/responses/CostAccountsResponse`
+
+
 ## v0.5.0
 ### V0
 - Replace `dimensions` ref to `#/components/schemas/Dimension`.

--- a/scripts/openapi-build.py
+++ b/scripts/openapi-build.py
@@ -25,7 +25,7 @@ TEMPLATE = """
   <meta charset="UTF-8">
   <title>Vic.AI OpenAPI Documentation</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.11.1/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui.css" >
   <style>
     html {
         box-sizing: border-box;
@@ -49,8 +49,8 @@ TEMPLATE = """
 
 <div id="swagger-ui"></div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.14.0/swagger-ui-bundle.js"> </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.14.0/swagger-ui-standalone-preset.js"> </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui-bundle.js"> </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui-standalone-preset.js"> </script>
 <script>
 window.onload = function() {
 

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -474,12 +474,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '200':
-          description: Expected response to a valid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Invoice'
+        "200":
+          $ref: "#/components/responses/InvoiceResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     patch:
@@ -3229,6 +3225,12 @@ components:
             $ref: "#/components/schemas/Invoices"
     InvoiceCreatedResponse:
       description: Invoice was created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Invoice"
+    InvoiceResponse:
+      description: A single invoice.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -841,12 +841,8 @@ paths:
                     schema:
                       type: string
       responses:
-        '201':
-          description: Successful upsert
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingInvoice'
+        "201":
+          $ref: "#/components/responses/TrainingInvoiceUpsertedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     delete:
@@ -3233,6 +3229,12 @@ components:
             $ref: "#/components/schemas/TrainingInvoices"
     TrainingInvoiceResponse:
       description: A single training invoice.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TrainingInvoice"
+    TrainingInvoiceUpsertedResponse:
+      description: Training invoice was successfully upserted.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -111,12 +111,8 @@ paths:
       tags:
         - general
       responses:
-        '200':
-          description: Successful health check response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HealthCheck'
+        "200":
+          $ref: "#/components/responses/HealthyResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /accounts:
@@ -3195,3 +3191,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/GetTokenResult"
+    HealthyResponse:
+      description: Successful health check response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/HealthCheck"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -259,18 +259,10 @@ paths:
             schema:
               $ref: '#/components/schemas/DimensionUpsert'
       responses:
-        '200':
-          description: Dimension was updated successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dimension'
-        '201':
-          description: Dimension was created successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dimension'
+        "200":
+          $ref: "#/components/responses/DimensionUpdatedResponse"
+        "201":
+          $ref: "#/components/responses/DimensionCreatedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     delete:
@@ -3205,6 +3197,18 @@ components:
             $ref: "#/components/schemas/Dimensions"
     DimensionResponse:
       description: A dimension.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Dimension"
+    DimensionCreatedResponse:
+      description: Dimension was created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Dimension"
+    DimensionUpdatedResponse:
+      description: Dimension was updated successfully.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -413,12 +413,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/RequestId'
       responses:
-        '200':
-          description: Vendor errors were cleared.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Vendor'
+        "200":
+          $ref: "#/components/responses/VendorRemoteErrorsClearedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /invoices:
@@ -3223,6 +3219,12 @@ components:
             $ref: "#/components/schemas/Vendor"
     VendorRemoteErrorsUpdatedResponse:
       description: Vendor errors were successfully updated.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Vendor"
+    VendorRemoteErrorsClearedResponse:
+      description: Vendor errors were successfully cleared.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -783,12 +783,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PathId'
       responses:
-        '200':
-          description: Expected response to a valid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingInvoice'
+        "200":
+          $ref: "#/components/responses/TrainingInvoiceResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     put:
@@ -3235,3 +3231,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/TrainingInvoices"
+    TrainingInvoiceResponse:
+      description: A single training invoice.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TrainingInvoice"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -952,12 +952,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '201':
-          description: Information from deleted vat code
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VatCode'
+        "201":
+          $ref: "#/components/responses/VatCodeDeletedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /subscription:
@@ -3245,6 +3241,12 @@ components:
             $ref: "#/components/schemas/VatCode"
     VatCodeUpsertedResponse:
       description: Vat code upserted successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/VatCode"
+    VatCodeDeletedResponse:
+      description: Vat code deleted successfully.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -399,12 +399,8 @@ paths:
             schema:
               $ref: '#/components/schemas/SetVendorRemoteErrors'
       responses:
-        '200':
-          description: Successful vendor error report
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Vendor'
+        "200":
+          $ref: "#/components/responses/VendorRemoteErrorsUpdatedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     delete:
@@ -3221,6 +3217,12 @@ components:
             $ref: "#/components/schemas/Vendor"
     VendorDeletedResponse:
       description: Vendor was successfully deleted.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Vendor"
+    VendorRemoteErrorsUpdatedResponse:
+      description: Vendor errors were successfully updated.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -275,12 +275,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '201':
-          description: Information from deleted dimension
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dimension'
+        "201":
+          $ref: "#/components/responses/DimensionDeletedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /vendors:
@@ -3209,6 +3205,12 @@ components:
             $ref: "#/components/schemas/Dimension"
     DimensionUpdatedResponse:
       description: Dimension was updated successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Dimension"
+    DimensionDeletedResponse:
+      description: Dimension was deleted successfully.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1040,6 +1040,12 @@ components:
       type: http
       scheme: bearer
 
+  headers:
+    NextPageToken:
+      description: A link to the next page of responses
+      schema:
+        type: string
+
   parameters:
     PathId:
       name: id
@@ -3019,9 +3025,7 @@ components:
       description: A paged array of accounts
       headers:
         x-next:
-          description: A link to the next page of responses
-          schema:
-            type: string
+          $ref: "#/components/headers/NextPageToken"
       content:
         application/json:
           schema:
@@ -3048,9 +3052,7 @@ components:
       description: A paged array of dimensions
       headers:
         x-next:
-          description: A link to the next page of responses
-          schema:
-            type: string
+          $ref: "#/components/headers/NextPageToken"
       content:
         application/json:
           schema:
@@ -3083,9 +3085,7 @@ components:
       description: A paged array of vendors
       headers:
         x-next:
-          description: A link to the next page of responses
-          schema:
-            type: string
+          $ref: "#/components/headers/NextPageToken"
       content:
         application/json:
           schema:
@@ -3130,9 +3130,7 @@ components:
       description: A paged array of invoices
       headers:
         x-next:
-          description: A link to the next page of responses
-          schema:
-            type: string
+          $ref: "#/components/headers/NextPageToken"
       content:
         application/json:
           schema:
@@ -3182,9 +3180,7 @@ components:
       description: A paged array of training invoices.
       headers:
         x-next:
-          description: A link to the next page of responses.
-          schema:
-            type: string
+          $ref: "#/components/headers/NextPageToken"
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -308,17 +308,8 @@ paths:
           schema:
             $ref: "#/components/schemas/VendorStateFilter"
       responses:
-        '200':
-          description: A paged array of vendors
-          headers:
-            x-next:
-              description: A link to the next page of responses
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Vendors'
+        "200":
+          $ref: "#/components/responses/VendorsResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /vendor/{id}:
@@ -3215,3 +3206,14 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Dimension"
+    VendorsResponse:
+      description: A paged array of vendors
+      headers:
+        x-next:
+          description: A link to the next page of responses
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Vendors"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -892,12 +892,8 @@ paths:
         - $ref: '#/components/parameters/SortOrder'
         - $ref: '#/components/parameters/VatCodeFilter'
       responses:
-        '200':
-          description: An array of vat codes
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VatCodes'
+        "200":
+          $ref: "#/components/responses/VatCodesResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /vatCode/{id}:
@@ -3243,3 +3239,9 @@ components:
       description: The document attached to the training invoice.
       content:
         application/pdf: {}
+    VatCodesResponse:
+      description: An array of vat codes
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/VatCodes"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -718,11 +718,7 @@ paths:
               $ref: '#/components/schemas/InvoiceReject'
       responses:
         "200":
-          description: The invoice was rejection error message was acknowledged.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Invoice'
+          $ref: "#/components/responses/InvoiceRejectedResponse"
         "403":
           $ref: "#/components/responses/ForbiddenResponse"
         "404":
@@ -3225,6 +3221,12 @@ components:
             format: binary
     InvoiceConfirmedResponse:
       description: The invoice was confirmed successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Invoice"
+    InvoiceRejectedResponse:
+      description: The invoice was rejection error message was acknowledged.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -355,18 +355,10 @@ paths:
             schema:
               $ref: '#/components/schemas/VendorUpsert'
       responses:
-        '200':
-          description: Vendor was successfully updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Vendor'
-        '201':
-          description: Vendor was successfully inserted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Vendor'
+        "200":
+          $ref: "#/components/responses/VendorUpdatedResponse"
+        "201":
+          $ref: "#/components/responses/VendorCreatedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     delete:
@@ -3215,6 +3207,18 @@ components:
             $ref: "#/components/schemas/Vendors"
     VendorResponse:
       description: A single vendor.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Vendor"
+    VendorCreatedResponse:
+      description: Vendor was successfully created.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Vendor"
+    VendorUpdatedResponse:
+      description: Vendor was successfully updated.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -373,12 +373,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '201':
-          description: Information from deleted vendor
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Vendor'
+        "201":
+          $ref: "#/components/responses/VendorDeletedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /vendor/{id}/errors:
@@ -3219,6 +3215,12 @@ components:
             $ref: "#/components/schemas/Vendor"
     VendorUpdatedResponse:
       description: Vendor was successfully updated.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Vendor"
+    VendorDeletedResponse:
+      description: Vendor was successfully deleted.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -749,14 +749,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: The ungrouped line items for the invoice.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/InvoiceLineItem'
+        "200":
+          $ref: "#/components/responses/InvoiceLineItemsResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /trainingInvoices:
@@ -3231,3 +3225,11 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Invoice"
+    InvoiceLineItemsResponse:
+      description: The ungrouped line items for the invoice.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/InvoiceLineItem"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -936,12 +936,8 @@ paths:
             schema:
               $ref: '#/components/schemas/VatCodeUpsert'
       responses:
-        '201':
-          description: Successful upsert
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VatCode'
+        "201":
+          $ref: "#/components/responses/VatCodeUpsertedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     delete:
@@ -3243,6 +3239,12 @@ components:
             $ref: "#/components/schemas/VatCodes"
     VatCodeResponse:
       description: A single vat code.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/VatCode"
+    VatCodeUpsertedResponse:
+      description: Vat code upserted successfully.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1030,12 +1030,8 @@ paths:
         - $ref: '#/components/parameters/SinceFilter'
         - $ref: '#/components/parameters/SortOrder'
       responses:
-        '200':
-          description: An array of cost accounts
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CostAccounts'
+        "200":
+          $ref: "#/components/responses/CostAccountsResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
 components:
@@ -3257,3 +3253,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/UnsubscribeResult"
+    CostAccountsResponse:
+      description: An array of cost accounts
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CostAccounts"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -532,12 +532,8 @@ paths:
                 - $ref: '#/components/schemas/InvoiceConfirm'
                 - $ref: '#/components/schemas/InvoiceReject'
       responses:
-        '201':
-          description: Expected response to a valid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Invoice'
+        "201":
+          $ref: "#/components/responses/InvoiceResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     delete:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -572,11 +572,7 @@ paths:
             type: string
       responses:
         "202":
-          description: Invoice has started processing.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Invoice"
+          $ref: "#/components/responses/InvoiceResponse"
         "403":
           $ref: "#/components/responses/ForbiddenResponse"
         "404":

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -130,17 +130,8 @@ paths:
         - $ref: '#/components/parameters/UseSystem'
         - $ref: '#/components/parameters/SortOrder'
       responses:
-        '200':
-          description: A paged array of accounts
-          headers:
-            x-next:
-              description: A link to the next page of responses
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Accounts'
+        "200":
+          $ref: "#/components/responses/AccountsResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /account/{id}:
@@ -3197,3 +3188,14 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/HealthCheck"
+    AccountsResponse:
+      description: A paged array of accounts
+      headers:
+        x-next:
+          description: A link to the next page of responses
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Accounts"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -989,12 +989,8 @@ paths:
             schema:
               $ref: '#/components/schemas/SubscriptionUpsert'
       responses:
-        '201':
-          description: Subscription successfully upserted.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SubscriptionUpsert'
+        "201":
+          $ref: "#/components/responses/SubscriptionUpsertedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
       callbacks:
@@ -3249,6 +3245,12 @@ components:
             $ref: "#/components/schemas/VatCode"
     SubscriptionResponse:
       description: The subscription information
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubscriptionUpsert"
+    SubscriptionUpsertedResponse:
+      description: Subscription successfully upserted.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -212,17 +212,8 @@ paths:
         - $ref: '#/components/parameters/UseSystem'
         - $ref: '#/components/parameters/SortOrder'
       responses:
-        '200':
-          description: A paged array of dimensions
-          headers:
-            x-next:
-              description: A link to the next page of responses
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dimensions'
+        "200":
+          $ref: "#/components/responses/DimensionsResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /dimension/{id}:
@@ -3205,3 +3196,14 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Account"
+    DimensionsResponse:
+      description: A paged array of dimensions
+      headers:
+        x-next:
+          description: A link to the next page of responses
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Dimensions"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -599,13 +599,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: Expected response to a valid request
-          content:
-            application/pdf:
-              schema:
-                type: string
-                format: binary
+        "200":
+          $ref: "#/components/responses/InvoiceDocumentResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     post:
@@ -3229,3 +3224,10 @@ components:
             $ref: "#/components/schemas/Invoice"
     InvoiceDeletedResponse:
       description: Invoice was successfully deleted.
+    InvoiceDocumentResponse:
+      description: The invoice's document.
+      content:
+        application/pdf:
+          schema:
+            type: string
+            format: binary

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -99,12 +99,8 @@ paths:
             schema:
               $ref: '#/components/schemas/GetTokenInput'
       responses:
-        '200':
-          description: Successful access token request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetTokenResult'
+        "200":
+          $ref: "#/components/responses/TokenCreatedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /healthCheck:
@@ -3193,3 +3189,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    TokenCreatedResponse:
+      description: Successful access token request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GetTokenResult"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -856,12 +856,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PathId'
       responses:
-        '201':
-          description: Information from deleted training invoice
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingInvoice'
+        "201":
+          $ref: "#/components/responses/TrainingInvoiceDeletedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /trainingInvoice/{id}/document:
@@ -3235,6 +3231,12 @@ components:
             $ref: "#/components/schemas/TrainingInvoice"
     TrainingInvoiceUpsertedResponse:
       description: Training invoice was successfully upserted.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TrainingInvoice"
+    TrainingInvoiceDeletedResponse:
+      description: Training invoice was successfully deleted.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -147,12 +147,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '200':
-          description: Expected response to a valid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Account'
+        "200":
+          $ref: "#/components/responses/AccountResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     put:
@@ -3199,3 +3195,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Accounts"
+    AccountResponse:
+      description: Shows the account.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Account"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -452,11 +452,7 @@ paths:
               $ref: "#/components/schemas/CreateInvoice"
       responses:
         "201":
-          description: Invoice was created successfully.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Invoice"
+          $ref: "#/components/responses/InvoiceCreatedResponse"
         "403":
           $ref: "#/components/responses/ForbiddenResponse"
         "404":
@@ -3231,3 +3227,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Invoices"
+    InvoiceCreatedResponse:
+      description: Invoice was created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Invoice"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -549,8 +549,8 @@ paths:
         - $ref: '#/components/parameters/UseSystem'
         - $ref: '#/components/parameters/Comment'
       responses:
-        '204':
-          description: Invoice was successfully deleted.
+        "204":
+          $ref: "#/components/responses/InvoiceDeletedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /invoice/{id}/process:
@@ -3231,3 +3231,5 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Invoice"
+    InvoiceDeletedResponse:
+      description: Invoice was successfully deleted.

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -872,10 +872,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PathId'
       responses:
-        '200':
-          description: Expected response for a valid training invoice
-          content:
-            application/pdf: {}
+        "200":
+          $ref: "#/components/responses/TrainingInvoiceDocumentResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /vatCodes:
@@ -3241,3 +3239,7 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/TrainingInvoice"
+    TrainingInvoiceDocumentResponse:
+      description: The document attached to the training invoice.
+      content:
+        application/pdf: {}

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -177,12 +177,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AccountUpsert'
       responses:
-        '201':
-          description: Successful upsert
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Account'
+        "201":
+          $ref: "#/components/responses/AccountUpsertedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     delete:
@@ -3197,6 +3193,12 @@ components:
             $ref: "#/components/schemas/Accounts"
     AccountResponse:
       description: Shows the account.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Account"
+    AccountUpsertedResponse:
+      description: Account was upserted successfully.
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -229,12 +229,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '200':
-          description: Expected response to a valid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dimension'
+        "200":
+          $ref: "#/components/responses/DimensionResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     put:
@@ -3207,3 +3203,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Dimensions"
+    DimensionResponse:
+      description: A dimension.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Dimension"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.5.0
+  version: 0.6.0
   contact: {}
   title: Vic.Api
   description: |

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -767,17 +767,8 @@ paths:
         - $ref: '#/components/parameters/SinceFilter'
         - $ref: '#/components/parameters/SortOrder'
       responses:
-        '200':
-          description: A paged array of invoices
-          headers:
-            x-next:
-              description: A link to the next page of responses
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TrainingInvoices'
+        "200":
+          $ref: "#/components/responses/TrainingInvoicesResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /trainingInvoice/{id}:
@@ -3233,3 +3224,14 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/InvoiceLineItem"
+    TrainingInvoicesResponse:
+      description: A paged array of training invoices.
+      headers:
+        x-next:
+          description: A link to the next page of responses.
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TrainingInvoices"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -679,11 +679,7 @@ paths:
               $ref: '#/components/schemas/InvoiceConfirm'
       responses:
         "200":
-          description: The invoice was confirmed successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Invoice'
+          $ref: "#/components/responses/InvoiceConfirmedResponse"
         "403":
           $ref: "#/components/responses/ForbiddenResponse"
         "404":
@@ -3227,3 +3223,9 @@ components:
           schema:
             type: string
             format: binary
+    InvoiceConfirmedResponse:
+      description: The invoice was confirmed successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Invoice"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -909,12 +909,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '200':
-          description: Expected response to a valid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VatCode'
+        "200":
+          $ref: "#/components/responses/VatCodeResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     put:
@@ -3245,3 +3241,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/VatCodes"
+    VatCodeResponse:
+      description: A single vat code.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/VatCode"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -638,11 +638,7 @@ paths:
                   nullable: false
       responses:
         "200":
-          description: Document was uploaded successfully.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Invoice"
+          $ref: "#/components/responses/InvoiceResponse"
         "403":
           $ref: "#/components/responses/ForbiddenResponse"
         "404":

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -433,17 +433,8 @@ paths:
         - $ref: '#/components/parameters/SortOrder'
         - $ref: '#/components/parameters/InvoiceStateFilter'
       responses:
-        '200':
-          description: A paged array of invoices
-          headers:
-            x-next:
-              description: A link to the next page of responses
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Invoices'
+        "200":
+          $ref: "#/components/responses/InvoicesResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     post:
@@ -3229,3 +3220,14 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Vendor"
+    InvoicesResponse:
+      description: A paged array of invoices
+      headers:
+        x-next:
+          description: A link to the next page of responses
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Invoices"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1012,12 +1012,8 @@ paths:
       tags:
         - subscriptions
       responses:
-        '201':
-          description: Successful deletion
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnsubscribeResult'
+        "201":
+          $ref: "#/components/responses/SubscriptionDeletedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /costAccounts:
@@ -3255,3 +3251,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/SubscriptionUpsert"
+    SubscriptionDeletedResponse:
+      description: Subscription successfully deleted.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UnsubscribeResult"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -964,12 +964,8 @@ paths:
       tags:
         - subscriptions
       responses:
-        '200':
-          description: The subscription information
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SubscriptionUpsert'
+        "200":
+          $ref: "#/components/responses/SubscriptionResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     put:
@@ -3251,3 +3247,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/VatCode"
+    SubscriptionResponse:
+      description: The subscription information
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubscriptionUpsert"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -193,12 +193,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '201':
-          description: Information for deleted account
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Account'
+        "201":
+          $ref: "#/components/responses/AccountDeletedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
   /dimensions:
@@ -3199,6 +3195,12 @@ components:
             $ref: "#/components/schemas/Account"
     AccountUpsertedResponse:
       description: Account was upserted successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Account"
+    AccountDeletedResponse:
+      description: Information for deleted account
       content:
         application/json:
           schema:

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -106,11 +106,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetTokenResult'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /healthCheck:
     get:
       description: Use this request to obtain a health check statement.
@@ -126,11 +122,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HealthCheck'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /accounts:
     get:
       description: |
@@ -158,11 +150,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Accounts'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /account/{id}:
     get:
       description: |
@@ -183,11 +171,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Account'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     put:
       description: |
         Use this request to *upsert* GL account data for one GL account into
@@ -221,11 +205,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Account'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     delete:
       description: |
         Use this request to delete data for a single account that is stored in
@@ -245,11 +225,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Account'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /dimensions:
     get:
       description: |
@@ -277,11 +253,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Dimensions'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /dimension/{id}:
     get:
       description: |
@@ -302,11 +274,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Dimension'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     put:
       description: |
         Use this request to *upsert* dimensions data for one dimension into
@@ -346,11 +314,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Dimension'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     delete:
       description: Use this request to delete data for a single dimension that is stored in Vic.ai
       summary: Deletes a dimension
@@ -368,11 +332,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Dimension'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /vendors:
     get:
       description: Use this request to query the vendor data that are stored in Vic.ai.
@@ -414,11 +374,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Vendors'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /vendor/{id}:
     get:
       description: Use this request to get data for a single vendor that is stored in Vic.ai.
@@ -437,11 +393,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Vendor'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     put:
       description: |
         Updates or inserts a vendor into the Vic.ai system.
@@ -483,11 +435,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Vendor'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     delete:
       description: |
         Use this request to delete data for a single vendor that is stored in
@@ -507,11 +455,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Vendor'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /vendor/{id}/errors:
     post:
       description: |
@@ -541,11 +485,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Vendor'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     delete:
       summary: Clears errors on the Vendor.
       description: Used to clear errors that have been fixed in the ERP system.
@@ -563,11 +503,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Vendor'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /invoices:
     get:
       description: |
@@ -596,11 +532,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Invoices'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     post:
       summary: Create an invoice.
       description: |
@@ -622,23 +554,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/Invoice"
         "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ForbiddenResponse"
         "404":
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ResourceNotFoundResponse"
         "422":
-          description: Input was invalid.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/UnprocessableEntityResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
   /invoice/{id}:
     get:
       description: |
@@ -659,11 +581,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Invoice'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     patch:
       description: |
         Use this request to indicate that an invoice has been posted or
@@ -725,11 +643,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Invoice'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     delete:
       description: |
         Use this request to delete data for a single invoice that is stored in
@@ -746,11 +660,7 @@ paths:
         '204':
           description: Invoice was successfully deleted.
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /invoice/{id}/process:
     post:
       summary: Start the invoice processing.
@@ -776,23 +686,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/Invoice"
         "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ForbiddenResponse"
         "404":
-          description: Invoice not found.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ResourceNotFoundResponse"
         "422":
-          description: Invoice failed to start processing.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/UnprocessableEntityResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
   /invoice/{id}/document:
     get:
       description: |
@@ -819,11 +719,7 @@ paths:
                 type: string
                 format: binary
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     post:
       summary: Upload document invoice
       description: |
@@ -865,23 +761,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/Invoice"
         "403":
-          description: Forbidden.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ForbiddenResponse"
         "404":
-          description: Invoice was not found.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ResourceNotFoundResponse"
         "422":
-          description: Errors with the input are present.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/UnprocessableEntityResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
   /invoice/{id}/confirm:
     post:
       description: |
@@ -920,23 +806,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Invoice'
         "403":
-          description: Forbidden.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ForbiddenResponse"
         "404":
-          description: Invoice was not found.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ResourceNotFoundResponse"
         "422":
-          description: Errors with the input are present.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/UnprocessableEntityResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
   /invoice/{id}/reject:
     post:
       description: |
@@ -973,23 +849,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Invoice'
         "403":
-          description: Forbidden.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ForbiddenResponse"
         "404":
-          description: Invoice was not found.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/ResourceNotFoundResponse"
         "422":
-          description: Errors with the input are present.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/UnprocessableEntityResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
   /invoice/{id}/lineItems:
     get:
       description: |
@@ -1021,11 +887,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/InvoiceLineItem'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /trainingInvoices:
     get:
       description: |
@@ -1052,11 +914,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TrainingInvoices'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /trainingInvoice/{id}:
     get:
       description: |
@@ -1076,11 +934,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TrainingInvoice'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     put:
       description: |
         Use this request to *upsert* training invoice data for one invoice into
@@ -1142,11 +996,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TrainingInvoice'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     delete:
       description: |
         Use this request to delete data for a single training invoice that is
@@ -1165,11 +1015,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TrainingInvoice'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /trainingInvoice/{id}/document:
     get:
       description: |
@@ -1187,11 +1033,7 @@ paths:
           content:
             application/pdf: {}
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /vatCodes:
     get:
       description: |
@@ -1215,11 +1057,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/VatCodes'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /vatCode/{id}:
     get:
       description: |
@@ -1240,11 +1078,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/VatCode'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     put:
       description: |
         Use this request to *upsert* vat code into Vic.ai.
@@ -1275,11 +1109,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/VatCode'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     delete:
       description: |
         Use this request to delete data for a single vat code that is stored in
@@ -1299,11 +1129,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/VatCode'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
   /subscription:
     get:
       description: Get the current status of the subscription that is set.
@@ -1319,11 +1145,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SubscriptionUpsert'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
     put:
       description: |
         This request is used to configure or modify a new subscription to user
@@ -1352,11 +1174,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SubscriptionUpsert'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
       callbacks:
         vendorNew:
           $ref: "#/components/callbacks/vendorNew"
@@ -1383,7 +1201,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UnsubscribeResult'
         default:
-          description: unexpected error
+          $ref: "#/components/responses/ErrorResponse"
   /costAccounts:
     get:
       description: |
@@ -1405,11 +1223,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CostAccounts'
         default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: "#/components/responses/ErrorResponse"
 components:
   securitySchemes:
     BearerAuth:
@@ -3348,3 +3162,34 @@ components:
     UnsubscribeResult:
       enum:
         - OK
+  responses:
+    UnauthorizedResponse:
+      description: The request was unauthorized.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    ForbiddenResponse:
+      description: The request was forbidden.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    ResourceNotFoundResponse:
+      description: Resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    UnprocessableEntityResponse:
+      description: Errors with the input are present.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    ErrorResponse:
+      description: An unexpected error has occurred. Check the body for more details.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -323,12 +323,8 @@ paths:
         - $ref: '#/components/parameters/PathId'
         - $ref: '#/components/parameters/UseSystem'
       responses:
-        '200':
-          description: Expected response to a valid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Vendor'
+        "200":
+          $ref: "#/components/responses/VendorResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
     put:
@@ -3217,3 +3213,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Vendors"
+    VendorResponse:
+      description: A single vendor.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Vendor"

--- a/vic.api.v1.yaml
+++ b/vic.api.v1.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.5.0
+  version: 0.6.0
   contact: {}
   title: Vic.Api
   description: |


### PR DESCRIPTION
The goal here is to compact each of the request definitions down some and provide for easy named references for response objects.

- Lift all error responses to the `#/components/responses` section.
- Replace `obtainToken` response with `#/components/responses/TokenCreatedResponse`
- Replace `healthCheck` response with `#/components/responses/HealthyResponse`
- Replace `listAccounts` response with `#/components/responses/AccountsResponse`
- Replace `getAccount` response with `#/components/responses/AccountResponse`
- Replace `upsertAccount` response with `#/components/responses/AccountUpsertedResponse`
- Replace `deleteAccount` response with `#/components/responses/AccountDeletedResponse`
- Replace `listDimensions` response with `#/components/responses/DimensionsResponse`
- Replace `getDimension` response with `#/components/responses/DimensionResponse`
- Replace `upsertDimension` response with `#/components/responses/DimensionCreatedResponse` and `#/components/responses/DimensionUpdatedResponse`
- Replace `deleteDimension` response with `#/components/responses/DimensionDeletedResponse`
- Replace `listVendors` response with `#/components/responses/VendorsResponse`
- Replace `getVendor` response with `#/components/responses/VendorResponse`
- Replace `upsertVendor` response with `#/components/responses/VendorCreatedResponse` and `#/components/responses/VendorUpdatedResponse`
- Replace `deleteVendor` response with `#/components/responses/VendorDeletedResponse`
- Replace `setVendorRemoteErrors` response with `#/components/responses/VendorRemoteErrorsUpdatedResponse`
- Replace `clearVendorRemoteErrors` response with `#/components/responses/VendorRemoteErrorsClearedResponse`
- Replace `listInvoices` response with `#/components/responses/InvoicesResponse`
- Replace `createInvoice` response with `#/components/responses/InvoiceCreatedResponse`
- Replace `getInvoice` response with `#/components/responses/InvoiceResponse`
- Replace `ackInvoice` response with `#/components/responses/InvoiceResponse`
- Replace `deleteInvoice` response with `#/components/responses/InvoiceDeletedResponse`
- Replace `startProcessingInvoice` response with `#/components/responses/InvoiceResponse`
- Replace `getInvoiceDocument` response with `#/components/responses/InvoiceDocumentResponse`
- Replace `confirmInvoice` response with `#/components/responses/InvoiceConfirmedResponse`
- Replace `rejectInvoice` response with `#/components/responses/InvoiceRejectedResponse`
- Replace `getInvoicelineItems` response with `#/components/responses/InvoiceLineItemsResponse`
- Replace `listTrainingInvoices` response with `#/components/responses/TrainingInvoicesResponse`
- Replace `upsertTrainingInvoice` response with `#/components/responses/TrainingInvoiceUpsertedResponse`
- Replace `deleteTrainingInvoice` response with `#/components/responses/TrainingInvoiceDeletedResponse`
- Replace `getTrainingInvoiceDocument` response with `#/components/responses/TrainingInvoiceDocumentResponse`
- Replace `listVatCodes` response with `#/components/responses/VatCodesResponse`
- Replace `getVatCode` response with `#/components/responses/VatCodeResponse`
- Replace `upsertVatCode` response with `#/components/responses/VatCodeUpsertedResponse`
- Replace `deleteVatCode` response with `#/components/responses/VatCodeDeletedResponse`
- Replace `getSubscription` response with `#/components/responses/SubscriptionResponse`
- Replace `subscribe` response with `#/components/responses/SubscriptionUpsertedResponse`
- Replace `unsubscribe` response with `#/components/responses/SubscriptionDeletedResponse`
- Replace `getCostAccounts` response with `#/components/responses/CostAccountsResponse`