### PR TITLE
feat: Add `typeExternalId` to `DimensionUpsert` and `Dimension` schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## v0.8.0
 ### V0
 - Deprecate singular resource path names in favor of pluralized paths. Old paths will be supported for at least 6 months. We recommend changing to the newer paths as soon as possible.
 - Changed `/v0/account/{id}` to `/v0/accounts/{id}`
@@ -21,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `/v0/vatCode/{id}` to `/v0/vatCodes/{id}`
 - Changed `/v0/vendor/{id}/errors` to `/v0/vendors/{id}/errors`
 - Changed `/v0/vendor/{id}` to `/v0/vendors/{id}`
+- Add `typeExternalId` to `#/components/schemas/Dimension`.
+- Add `typeExternalId` to `#/components/schemas/DimensionUpsert`.
+- Changed set max length for `type` on `#/components/schemas/Dimension`.
+- Changed set max length for `type` on `#/components/schemas/DimensionUpsert`.
+- Changed set max length for `name` on `#/components/schemas/Dimension`.
+- Changed set max length for `name` on `#/components/schemas/DimensionUpsert`.
+- Changed `name` to be required for `#/components/schemas/DimensionUpsert`.
 
 
 ## v0.7.0

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.6.1
+  version: 0.8.0
   contact: {}
   title: Vic.Api
   description: |
@@ -1614,8 +1614,15 @@ components:
         name:
           type: string
           maxLength: 255
+          description: The name of the dimension.
         type:
           type: string
+          maxLength: 255
+          description: The dimension type name.
+        typeExternalId:
+          type: string
+          maxLength: 255
+          description: The dimension type's external ID in the ERP system.
         shortName:
           type: string
           maxLength: 255
@@ -1641,7 +1648,8 @@ components:
     DimensionUpsert:
       type: object
       required:
-      - externalUpdatedAt
+        - externalUpdatedAt
+        - name
       properties:
         externalId:
           $ref: '#/components/schemas/ExternalId'
@@ -1653,8 +1661,17 @@ components:
         name:
           type: string
           maxLength: 255
+          description: The name of the dimension.
         type:
           type: string
+          maxLength: 255
+          description: The dimension type name.
+        typeExternalId:
+          type: string
+          maxLength: 255
+          description: |-
+            The type's external ID in the ERP system. If left unspecified, it
+            will clear the existing value.
         shortName:
           type: string
           maxLength: 255


### PR DESCRIPTION
* Adds the `typeExternalId` to `DimensionUpsert` and `Dimension` schemas.
* Sets max length for inputs for `type` and `name`.
* Mark `name` as required.