### PR TITLE
feat: `invoiceTransfer` callback will now receive the same payload as `invoicePost`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.10.0
 ### V0
 - Added `createDimension` operation.
+- `invoiceTransfer` callback will now receive the same payload as the `invoicePost` callback.
 
 ## v0.9.0
 ### V0
-- Added `externalTypeId` to `#/components/schemas/DimensionRef`.
+- Added `typeExternalId` to `#/components/schemas/DimensionRef`.
 - Expanded documentation for `#/components/schemas/DimensionRef`.
 - Deprecated `dimensionsExternalIds` in `#/components/schemas/TrainingInvoiceLineItemUpsert`. Instead please use the `dimensions` field which has the same functionality as the `createInvoice` operation.
 

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.9.0
+  version: 0.10.0
   contact: {}
   title: Vic.Api
   description: |
@@ -1180,10 +1180,20 @@ paths:
               requestBody:
                 required: true
                 content:
-                  application/pdf:
+                  multipart/form-data:
                     schema:
-                      type: string
-                      format: binary
+                      type: object
+                      properties:
+                        invoiceData:
+                          $ref: "#/components/schemas/Invoice"
+                        invoiceDocument:
+                          type: string
+                          format: binary
+                    encoding:
+                      invoiceData:
+                        contentType: application/json
+                      invoiceDocument:
+                        contentType: application/pdf
               responses:
                 "201":
                   description: Successful upsert


### PR DESCRIPTION
These two callbacks will have the same payload. 