### PR TITLE
fix: misc corrections

### DIFF
--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2378,6 +2378,7 @@ components:
         - poNumber
         - amount
         - vendor
+        - lineItems
       properties:
         externalId:
           type: string


### PR DESCRIPTION
Fixing things I find while working on `DERP` purchase orders

- `lineItems` seems to be a required field when creating purchase order