### PR TITLE
Add bill of lading and type name for dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.16.0
+
+- Replaced `bolNumber` with `bolNumbers` for `#/components/schemas/Invoice`.
+- Replaced `bolNumber` with `bolNumbers` for `#/components/schemas/TrainingInvoice`.
+- Replaced `bolNumber` with `bolNumbers` for `#/components/schemas/CreateInvoice`.
+- Replaced `bolNumber` with `bolNumbers` for `#/components/schemas/TrainingInvoiceUpsert`.
+- Added `typeName` to `#/components/schemas/Dimension`.
+- Added `typeName` to `#/components/schemas/DimensionUpsert`.
+- Added support for managing payment terms.
+
 ## v0.14.1
 
-- Removed pattern constraint from `#/components/schemas/Account`
-- Removed pattern constraint from `#/components/schemas/AccountUpsert`
-- Removed pattern constraint from `#/components/schemas/CostAccountInfo`'
-- Added `#/components/schemas/VendorManager`
-- Allow passing `managers` (`#/components/schemas/VendorManager`) to `#/components/schemas/VendorUpsert`
+- Removed pattern constraint from `#/components/schemas/Account`.
+- Removed pattern constraint from `#/components/schemas/AccountUpsert`.
+- Removed pattern constraint from `#/components/schemas/CostAccountInfo`.
+- Added `#/components/schemas/VendorManager`.
+- Allow passing `managers` (`#/components/schemas/VendorManager`) to `#/components/schemas/VendorUpsert`.
 
 ## v0.14.0
 

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2312,11 +2312,6 @@ components:
           description: Number that appears on the invoice.
           type: string
           maxLength: 255
-        bolNumber:
-          description: The bill of lading number.
-          type: string
-          maxLength: 255
-          nullable: true
         poNumber:
           type: string
           nullable: true
@@ -2893,11 +2888,6 @@ components:
           description: number that appears on the invoice
           type: string
           maxLength: 255
-        bolNumber:
-          description: The bill of lading number.
-          type: string
-          maxLength: 255
-          nullable: true
         poNumber:
           type: string
           nullable: true
@@ -2947,11 +2937,6 @@ components:
           $ref: '#/components/schemas/TransactionType'
         refNumber:
           description: number that appears on the invoice
-          type: string
-          maxLength: 255
-          nullable: true
-        bolNumber:
-          description: The bill of lading number.
           type: string
           maxLength: 255
           nullable: true

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -65,6 +65,13 @@ tags:
       - Invoices which have been posted to the ERP system.
 
       By default, access to unposted invoices is restricted.
+  - name: PaymentTerms
+    description: |
+      Payment Terms are part of your *ERP* **Masterdata**, that represent
+      payment terms that Vic.ai can automatically assign to invoices. Some
+      vendors may have a default payment term, and some invoices may have a
+      specific payment term. In either case, Vic.ai can automatically assign
+      payment terms to invoices.
   - name: PurchaseOrders
   - name: Subscriptions
     description: |
@@ -1614,6 +1621,72 @@ paths:
           $ref: "#/components/responses/VendorTagDeletedResponse"
         default:
           $ref: "#/components/responses/ErrorResponse"
+  /paymentTerms:
+    get:
+      description: |
+        Get a list of payment terms.
+      summary: Get a list of payment terms
+      operationId: listPaymentTerms
+      tags:
+        - PaymentTerms
+      responses:
+        "200":
+          $ref: "#/components/responses/PaymentTermListResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
+    post:
+      description: |
+        Create a new payment term.
+      summary: Create a new payment term
+      operationId: createPaymentTerm
+      tags:
+        - PaymentTerms
+      requestBody:
+        $ref: "#/components/requestBodies/CreatePaymentTermRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/PaymentTermResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntityResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
+  /paymentTerms/{id}:
+    put:
+      description: |
+        Update a payment term.
+      summary: Update a payment term
+      operationId: updatePaymentTerm
+      tags:
+        - PaymentTerms
+      parameters:
+        - $ref: '#/components/parameters/PaymentTermId'
+      requestBody:
+        $ref: "#/components/requestBodies/UpdatePaymentTermRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/PaymentTermResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntityResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
+    delete:
+      description: |
+        Delete a payment term.
+      summary: Delete a payment term
+      operationId: deletePaymentTerm
+      tags:
+        - PaymentTerms
+      parameters:
+        - $ref: '#/components/parameters/PaymentTermId'
+      responses:
+        "204":
+          $ref: "#/components/responses/PaymentTermDeletedResponse"
+        default:
+          $ref: "#/components/responses/ErrorResponse"
 
 components:
   securitySchemes:
@@ -1762,6 +1835,13 @@ components:
       in: path
       required: true
       description: The id of the vendor tag
+      schema:
+        type: string
+    PaymentTermId:
+      name: id
+      in: path
+      required: true
+      description: The id of the payment term
       schema:
         type: string
 
@@ -2169,7 +2249,7 @@ components:
           minimum: 0
           description: The number of `unit` for the payment term.
         unit:
-          $ref: "#/components/schemas/PaymentTermUnit"
+          $ref: "#/components/schemas/PaymentInfoTermUnit"
     LineItemVat:
       type: object
       properties:
@@ -2199,6 +2279,102 @@ components:
           description: |
             The amount of VAT. If the VAT amount is unknown, this should be left
             `NULL` or unspecified.
+    CreatePaymentTerm:
+      type: object
+      required:
+        - name
+        - daysToPay
+      properties:
+        name:
+          type: string
+          nullable: false
+          maxLength: 255
+          description: The name of the payment term
+        daysToPay:
+          type: integer
+          minimum: 1
+          description: The number of days the invoice should be paid in.
+        description:
+          type: string
+          nullable: true
+          maxLength: 255
+          description: A description of the payment term.
+        discountDays:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: The number of days the invoice should be paid in to get a discount.
+        discountPercentage:
+          type: string
+          format: decimal
+          nullable: true
+          minimum: 0
+          description: The discount percentage if paid within the number of discount days.
+    UpdatePaymentTerm:
+      type: object
+      required:
+        - name
+        - daysToPay
+      properties:
+        name:
+          type: string
+          nullable: false
+          maxLength: 255
+          description: The name of the payment term
+        daysToPay:
+          type: integer
+          minimum: 1
+          description: The number of days the invoice should be paid in.
+        description:
+          type: string
+          nullable: true
+          maxLength: 255
+          description: A description of the payment term.
+        discountDays:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: The number of days the invoice should be paid in to get a discount.
+        discountPercentage:
+          type: string
+          format: decimal
+          nullable: true
+          minimum: 0
+          description: The discount percentage if paid within the number of discount days.
+    PaymentTerm:
+      type: object
+      required:
+        - name
+        - daysToPay
+      properties:
+        id:
+          type: string
+          description: The payment term's id.
+        name:
+          type: string
+          nullable: false
+          maxLength: 255
+          description: The name of the payment term
+        daysToPay:
+          type: integer
+          minimum: 1
+          description: The number of days the invoice should be paid in.
+        description:
+          type: string
+          nullable: true
+          maxLength: 255
+          description: A description of the payment term.
+        discountDays:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: The number of days the invoice should be paid in to get a discount.
+        discountPercentage:
+          type: string
+          format: decimal
+          nullable: true
+          minimum: 0
+          description: The discount percentage if paid within the number of discount days.
     CreateInvoiceLineItem:
       type: object
       required:
@@ -3649,12 +3825,12 @@ components:
           $ref: '#/components/schemas/ErrorString'
         message:
           $ref: '#/components/schemas/ErrorString'
-    PaymentTermUnit:
+    PaymentInfoTermUnit:
       type: string
       description: The payment term units supported.
       enum:
         - DAYS
-    PaymentTerm:
+    PaymentInfoTerm:
       type: object
       required:
         - count
@@ -3664,7 +3840,7 @@ components:
           type: integer
           minimum: 1
         unit:
-          $ref: "#/components/schemas/PaymentTermUnit"
+          $ref: "#/components/schemas/PaymentInfoTermUnit"
     AccrualTermUnit:
       type: string
       description: The accrual term units supported.
@@ -3754,7 +3930,7 @@ components:
           nullable: true
         paymentTerm:
           allOf:
-            - $ref: "#/components/schemas/PaymentTerm"
+            - $ref: "#/components/schemas/PaymentInfoTerm"
           nullable: true
         bankGiro:
           type: string
@@ -3915,6 +4091,7 @@ components:
       properties:
         bolNumber:
           type: string
+
   requestBodies:
     CreatePurchaseOrderRequest:
       description: Create a purchase order.
@@ -3968,7 +4145,20 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CreateVendorTag'
-    
+    CreatePaymentTermRequest:
+      description: Create a payment term.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatePaymentTerm'
+    UpdatePaymentTermRequest:
+      description: Update a payment term.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdatePaymentTerm'
 
   responses:
     ForbiddenResponse:
@@ -4285,3 +4475,17 @@ components:
             $ref: "#/components/schemas/VendorTag"
     VendorTagDeletedResponse:
       description: Vendor tag was successfully deleted.
+    PaymentTermListResponse:
+      description: A list of payment terms.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PaymentTerm"
+    PaymentTermResponse:
+      description: A single payment term.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PaymentTerm"
+    PaymentTermDeletedResponse:
+      description: Payment term was successfully deleted.

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1891,7 +1891,11 @@ components:
         type:
           type: string
           maxLength: 255
-          description: The dimension type name.
+          description: The dimension type.
+        typeName:
+          type: string
+          maxLength: 255
+          description: The dimension type name. A human friendly type name.
         typeExternalId:
           type: string
           maxLength: 255
@@ -1938,6 +1942,10 @@ components:
         type:
           type: string
           maxLength: 255
+          description: The dimension type.
+        typeName:
+          type: string
+          maxLength: 255
           description: The dimension type name.
         typeExternalId:
           type: string
@@ -1970,6 +1978,10 @@ components:
           maxLength: 255
           description: The name of the dimension.
         type:
+          type: string
+          maxLength: 255
+          description: The dimension type.
+        typeName:
           type: string
           maxLength: 255
           description: The dimension type name.

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.14.0
+  version: 0.16.0
   contact: {}
   title: Vic.Api
   description: |

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2381,6 +2381,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CreateInvoiceLineItem"
+        bolNumbers:
+          type: array
+          items:
+            $ref: "#/components/schemas/BillOfLadingNumber"
     CreatePurchaseOrder:
       required:
         - poNumber
@@ -2716,6 +2720,10 @@ components:
           format: url
         status:
           $ref: '#/components/schemas/InvoiceState'
+        bolNumbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillOfLadingNumber'
     InvoiceConfirm:
       type: object
       required:
@@ -2869,7 +2877,6 @@ components:
           type: string
           nullable: true
           maxLength: 255
-
     TrainingInvoice:
       type: object
       required:
@@ -2926,6 +2933,10 @@ components:
           allOf:
           - $ref: '#/components/schemas/ExternalData'
           nullable: true
+        bolNumbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillOfLadingNumber'
     TrainingInvoiceUpsert:
       type: object
       required:
@@ -3002,6 +3013,10 @@ components:
           format: date-time
           description: Does not have UTC normalization.
           example: '2021-06-29T17:20:53.154'
+        bolNumbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillOfLadingNumber'
     Invoices:
       type: array
       items:
@@ -3891,6 +3906,14 @@ components:
           type: string
           description: The purchase order item's internal id.
         quantityMatched:
+          type: string
+    BillOfLadingNumber:
+      description: The bill of lading number.
+      type: object
+      required:
+        - bolNumber
+      properties:
+        bolNumber:
           type: string
   requestBodies:
     CreatePurchaseOrderRequest:


### PR DESCRIPTION
- Replaced `bolNumber` with `bolNumbers` for `#/components/schemas/Invoice`.
- Replaced `bolNumber` with `bolNumbers` for `#/components/schemas/TrainingInvoice`.
- Replaced `bolNumber` with `bolNumbers` for `#/components/schemas/CreateInvoice`.
- Replaced `bolNumber` with `bolNumbers` for `#/components/schemas/TrainingInvoiceUpsert`.
- Added `typeName` to `#/components/schemas/Dimension`.
- Added `typeName` to `#/components/schemas/DimensionUpsert`.
- Added support for managing payment terms.

closes #53 