### PR TITLE
fix: Add missing documentation for `paymentTermId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.17.1
+
+- Added `paymentTermId` to `#/components/schemas/Vendor`.
+- Added `paymentTermId` to `#/components/schemas/VendorUpsert`.
+- Added `paymentTermId` to `#/components/schemas/VendorCallback`.
+
 ## v0.17.0
 
 - Allow nullable `productNumber` for `#/components/schemas/CreatePurchaseOrderItem`.

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.17.0
+  version: 0.17.1
   contact: {}
   title: Vic.Api
   description: |
@@ -3624,6 +3624,10 @@ components:
           $ref: '#/components/schemas/VendorTaxInfo'
         defaultPaymentInfo:
           $ref: "#/components/schemas/PaymentInfo"
+        paymentTermId:
+          description: The id of the `PaymentTerm` a vendor uses.
+          type: string
+          nullable: true
         externalData:
           allOf:
           - $ref: '#/components/schemas/ExternalData'
@@ -3688,6 +3692,10 @@ components:
           $ref: '#/components/schemas/VendorTaxInfo'
         defaultPaymentInfo:
           $ref: "#/components/schemas/PaymentInfo"
+        paymentTermId:
+          description: The id of the `PaymentTerm` a vendor uses.
+          type: string
+          nullable: true
         externalData:
           allOf:
           - $ref: '#/components/schemas/ExternalData'
@@ -3755,6 +3763,10 @@ components:
           $ref: '#/components/schemas/VendorTaxInfo'
         defaultPaymentInfo:
           $ref: "#/components/schemas/PaymentInfo"
+        paymentTermId:
+          description: The id of the `PaymentTerm` a vendor uses.
+          type: string
+          nullable: true
         externalData:
           allOf:
             - $ref: '#/components/schemas/ExternalData'


### PR DESCRIPTION
This was meant to be added in the `v0.17.0` release but was over looked.