### PR TITLE
feat(custom_fields): Add custom fields support to `Invoice` and `TrainingInvoice`

### DIFF
--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -3492,6 +3492,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BillOfLadingNumber'
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceField'
     TrainingInvoiceUpsert:
       type: object
       required:
@@ -3573,6 +3577,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BillOfLadingNumber'
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceFieldInput'
     Invoices:
       type: array
       items:
@@ -4324,12 +4332,10 @@ components:
       required: [label, value]
       properties:
         label:
-          description: The label of the invoice field, prefixed with `custom:`.
           maxLength: 255
           nullable: false
           type: string
         value:
-          description: The value of the invoice field.
           maxLength: 255
           nullable: true
           type: string

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2896,6 +2896,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BillOfLadingNumber'
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceFieldInput'
     CreateTaxCode:
       required: [code, description, rate]
       properties:
@@ -3200,6 +3204,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CustomField'
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceField'
         language:
           type: string
           nullable: true
@@ -4292,6 +4300,39 @@ components:
         label:
           type: string
           maxLength: 255
+    InvoiceField:
+      type: object
+      properties:
+        label:
+          type: string
+          maxLength: 255
+          nullable: false
+        title:
+          type: string
+          maxLength: 255
+          nullable: false
+        type:
+          type: string
+          maxLength: 255
+          nullable: false
+        value:
+          type: string
+          maxLength: 255
+          nullable: true
+    InvoiceFieldInput:
+      type: object
+      required: [label, value]
+      properties:
+        label:
+          description: The label of the invoice field, prefixed with `custom:`.
+          maxLength: 255
+          nullable: false
+          type: string
+        value:
+          description: The value of the invoice field.
+          maxLength: 255
+          nullable: true
+          type: string
     VendorTaxInfo:
       type: object
       properties:


### PR DESCRIPTION
- Add `Invoice.fields`
- Add `CreateInvoice.fields`
- Add `TrainingInvoice.fields`
- Add `TrainingInvoiceUpsert.fields`