### PR TITLE
chore: nodejs 21.6.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 21.7.1
+nodejs 21.6.2


### PR DESCRIPTION
```bash
 ~/v/api-docs  chore-nodejs-21.6.2  asdf install nodejs 21.7.1                      
Trying to update node-build... ok
node-build: definition not found: 21.7.1
```