### PR TITLE
chore: Add settlement info to Payment/Credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `vatRate` to `#/components/schemas/InvoiceLineItemInfo`
 - Add `totalAmount` to `#/components/schemas/CreateInvoice`
 - Add `totalAmount` to `#/components/schemas/TrainingInvoiceUpsert`
+- Add `settlementAmount` to `#/components/schemas/Payment`
+- Add `settlementAmount` to `#/components/schemas/Credit`
+- Add `settlementCurrencyId` to `#/components/schemas/Payment`
+- Add `settlementCurrencyId` to `#/components/schemas/Credit`
+- Add `exchangeRate` to `#/components/schemas/Credit`
+- Add `exchangeRate` to `#/components/schemas/Payment`
 - Fix incorrect documentation for `#/components/schemas/LineItemVat`
 - Fix incorrect documentation for `#/components/schemas/CreateInvoiceLineItem`
 - Fix incorrect documentation for `#/components/schemas/TrainingInvoiceLineItemUpsert`

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2284,8 +2284,14 @@ components:
           description: The id of the credit.
         amount:
           $ref: '#/components/schemas/MonetaryValue'
+        settlementAmount:
+          $ref: '#/components/schemas/MonetaryValue'
         currencyId:
           $ref: '#/components/schemas/Currency'
+        settlementCurrencyId:
+          $ref: '#/components/schemas/Currency'
+        exchangeRate:
+          $ref: '#/components/schemas/MonetaryValue'
         status:
           $ref: '#/components/schemas/CreditStatus'
         approvedAt:
@@ -2345,6 +2351,8 @@ components:
           description: The id of the credit.
         amount:
           $ref: '#/components/schemas/MonetaryValue'
+        settlementAmount:
+          $ref: '#/components/schemas/MonetaryValue'
         discountAmount:
           description: |
             The discount amount applied using the `PaymentTerm` on the vendor.
@@ -2356,6 +2364,10 @@ components:
             - $ref: '#/components/schemas/MonetaryValue'
         currencyId:
           $ref: '#/components/schemas/Currency'
+        settlementCurrencyId:
+          $ref: '#/components/schemas/Currency'
+        exchangeRate:
+          $ref: '#/components/schemas/MonetaryValue'
         status:
           $ref: '#/components/schemas/PaymentStatus'
         approvedAt:


### PR DESCRIPTION
Add `settlementAmount`, `settlementCurrencyId`, `exchangeRate` to `Payment` and `Credit` schema.

Resolves: Resolves: https://vicaiglobal.atlassian.net/browse/ENG-9937
Related PR: https://github.com/Vic-ai/vic-api/pull/9008