### PR TITLE
feat: Add `number` and `unitPrice` to invoice items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add `number` to `#/components/schemas/CreateInvoiceLineItem`
+- Add `number` to `#/components/schemas/InvoiceLineItem`
+- Add `number` to `#/components/schemas/TrainingInvoiceLineItemUpsert`
+- Add `unitPrice` to `#/components/schemas/CreateInvoiceLineItem`
+- Add `unitPrice` to `#/components/schemas/TrainingInvoiceLineItemUpsert`
+
 ## v0.20.0
 
 - Add `vatRate` to `#/components/schemas/InvoiceLineItemInfo`.

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2744,6 +2744,17 @@ components:
               items:
                 $ref: '#/components/schemas/DimensionRef'
             - type: 'null'
+        unitPrice:
+          description: The price per unit of the item.
+          oneOf:
+            - $ref: '#/components/schemas/MonetaryValue'
+            - type: 'null'
+        number:
+          description: The item number
+          oneOf:
+            - type: string
+              maxLength: 255
+            - type: 'null'
     InvoiceIneternalId:
       type: string
       description: The id of the `Invoice` in Vic.
@@ -3884,6 +3895,12 @@ components:
           oneOf:
             - $ref: '#/components/schemas/MonetaryValue'
             - type: 'null'
+        number:
+          description: The item number
+          oneOf:
+            - type: string
+              maxLength: 255
+            - type: 'null'
     TrainingInvoiceLineItemUpsert:
       type: object
       required: [amount]
@@ -3946,6 +3963,17 @@ components:
               format: decimal
             - type: 'null'
           description: The quantity of things that were invoiced.
+        unitPrice:
+          description: The price per unit of the item.
+          oneOf:
+            - $ref: '#/components/schemas/MonetaryValue'
+            - type: 'null'
+        number:
+          description: The item number
+          oneOf:
+            - type: string
+              maxLength: 255
+            - type: 'null'
     VatCode:
       type: object
       required: [internalId, internalUpdatedAt, code, description]


### PR DESCRIPTION
- Add `number` to `#/components/schemas/CreateInvoiceLineItem`
- Add `number` to `#/components/schemas/InvoiceLineItem`
- Add `number` to `#/components/schemas/TrainingInvoiceLineItemUpsert`
- Add `unitPrice` to `#/components/schemas/CreateInvoiceLineItem`
- Add `unitPrice` to `#/components/schemas/TrainingInvoiceLineItemUpsert`