### PR TITLE
feat: Add `taxCodeId` to `TrainingInvoiceLineItemUpsert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Add `taxCodeId` to `#/components/schemas/TrainingInvoiceLineItemUpsert`
+
 
 ## v0.21.0
 
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `siteOwner` to `#/components/schemas/CreatePurchaseOrder`
 - Add `siteOwner` to `#/components/schemas/UpdatePurchaseOrder`
 - Add `taxCode` to `#/components/schemas/InvoiceLineItem`
+- Add `taxCodeId` to `#/components/schemas/TrainingInvoiceLineItemUpsert`
 
 
 ## v0.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+- Add `taxCodeId` to `#/components/schemas/TrainingInvoiceLineItemUpsert`
 
 ## v0.21.0
 

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -4005,6 +4005,12 @@ components:
             - type: string
               maxLength: 255
             - type: 'null'
+        taxCodeId:
+          oneOf:
+            - type: string
+              format: uuid
+              description: ID of Tax Code to use for the line item.
+            - type: 'null'
     VatCode:
       type: object
       required: [internalId, internalUpdatedAt, code, description]


### PR DESCRIPTION
Document `taxCodeId` on `TrainingInvoiceLineItemUpsert`. I think this was the last missing tax code documentation.