### PR TITLE
feat: Add ability to retrieve payment terms using external id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `POST - /v0/purchaseOrders/synchronize` to synchronize Purchase Orders.
 - Add `POST - /v0/vatCodes/synchronize` to synchronize Vat Codes.
 - Add `POST - /v0/vendors/synchronize` to synchronize Vendors.
-
+- Add `GET - /v0/paymentTerms/{id}` to fetch a payment term using the internal
+  id or external id if `useSystem=external` is passed.
+- Add support for `useSystem=external` for `updatePaymentTerm` and
+  `deletePaymentTerm`.
 
 ## v0.21.0
 

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1774,14 +1774,37 @@ paths:
         '4XX':
           $ref: '#/components/responses/ErrorResponse'
   /paymentTerms/{id}:
+    get:
+      description: |
+        Get a payment term.
+        You may use the `externalId` in the, but must pass `useSystem=external`
+        in order to fetch the payment term.
+      summary: Get a payment term
+      operationId: getPaymentTerm
+      tags: [Payment terms]
+      parameters:
+        - $ref: '#/components/parameters/PathId'
+        - $ref: '#/components/parameters/UseSystem'
+      responses:
+        '200':
+          $ref: '#/components/responses/PaymentTermResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundResponse'
     put:
       description: |
         Update a payment term.
+        You may use the `externalId` in the, but must pass `useSystem=external`
+        in order to fetch the payment term. You are permitted to update the
+        `externalId` as well when updating the payment term. Leaving it
+        unspecified **WILL** clear the `externalId`.
       summary: Update a payment term
       operationId: updatePaymentTerm
       tags: [Payment terms]
       parameters:
-        - $ref: '#/components/parameters/PaymentTermId'
+        - $ref: '#/components/parameters/PathId'
+        - $ref: '#/components/parameters/UseSystem'
       requestBody:
         $ref: '#/components/requestBodies/UpdatePaymentTermRequest'
       responses:
@@ -1794,11 +1817,14 @@ paths:
     delete:
       description: |
         Delete a payment term.
+        You may use the `externalId` in the, but must pass `useSystem=external`
+        in order to fetch the payment term.
       summary: Delete a payment term
       operationId: deletePaymentTerm
       tags: [Payment terms]
       parameters:
-        - $ref: '#/components/parameters/PaymentTermId'
+        - $ref: '#/components/parameters/PathId'
+        - $ref: '#/components/parameters/UseSystem'
       responses:
         '204':
           $ref: '#/components/responses/PaymentTermDeletedResponse'

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -1777,8 +1777,8 @@ paths:
     get:
       description: |
         Get a payment term.
-        You may use the `externalId` in the, but must pass `useSystem=external`
-        in order to fetch the payment term.
+        The `id` in the path can be either the Payment Term's internal ID or its
+        external ID when `useSystem=external` is included in the query string.
       summary: Get a payment term
       operationId: getPaymentTerm
       tags: [Payment terms]
@@ -1795,10 +1795,11 @@ paths:
     put:
       description: |
         Update a payment term.
-        You may use the `externalId` in the, but must pass `useSystem=external`
-        in order to fetch the payment term. You are permitted to update the
-        `externalId` as well when updating the payment term. Leaving it
-        unspecified **WILL** clear the `externalId`.
+        The `id` in the path can be either the Payment Term's internal ID or its
+        external ID when `useSystem=external` is included in the request. The
+        Payment Term's external ID can be updated by including `externalId={value}`
+        in the request body. If the `externalId` key is present without a value,
+        the Payment Term's `externalId` **WILL** be cleared.
       summary: Update a payment term
       operationId: updatePaymentTerm
       tags: [Payment terms]
@@ -1817,8 +1818,8 @@ paths:
     delete:
       description: |
         Delete a payment term.
-        You may use the `externalId` in the, but must pass `useSystem=external`
-        in order to fetch the payment term.
+        The `id` in the path can be either the Payment Term's internal ID or its
+        external ID when `useSystem=external` is included in the query string.
       summary: Delete a payment term
       operationId: deletePaymentTerm
       tags: [Payment terms]

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2781,6 +2781,12 @@ components:
                 The discount percentage if paid within the number of discount
                 days.
             - type: 'null'
+        externalId:
+          description: The ID of the payment term in the ERP if it has one.
+          oneOf:
+            - type: string
+              maxLength: 255
+            - type: 'null'
     PaymentTerm:
       type: object
       required: [name, daysToPay]
@@ -2818,6 +2824,12 @@ components:
               description: |
                 The discount percentage if paid within the number of discount
                 days.
+            - type: 'null'
+        externalId:
+          description: The ID of the payment term in the ERP if it has one.
+          oneOf:
+            - type: string
+              maxLength: 255
             - type: 'null'
     CreateInvoiceLineItem:
       type: object

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2738,6 +2738,12 @@ components:
                 days.
               minimum: 0
             - type: 'null'
+        externalId:
+          description: The ID of the payment term in the ERP if it has one.
+          oneOf:
+            - type: string
+              maxLength: 255
+            - type: 'null'
     UpdatePaymentTerm:
       type: object
       required: [name, daysToPay]

--- a/vic.api.v0.yaml
+++ b/vic.api.v0.yaml
@@ -2069,13 +2069,6 @@ components:
       description: The id of the vendor tag
       schema:
         type: string
-    PaymentTermId:
-      name: id
-      in: path
-      required: true
-      description: The id of the payment term
-      schema:
-        type: string
   #
   # Shared Schemas
   #


### PR DESCRIPTION
* Get a payment term using internal id or external id.
* Update a payment term using internal id or external id.
* Update a payment term's external id.
* Delete a payment term using internal id or external id.
* Create a payment with an external id. Upsert is not implemented, nor will it be.